### PR TITLE
Add CDN jQuery

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -45,6 +45,9 @@
 
     {{! Footer include }}    
     {{> footer}}
+    
+    {{!-- jQuery needs to come before `{{ghost_foot}}` so that jQuery can be used in code injection --}}
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
 
     {{! Ghost outputs important scripts and data with this tag }}
     {{ghost_foot}}


### PR DESCRIPTION
Ghost no longer outputs jquery in ghost_foot (see [relevant blog post](https://dev.ghost.org/no-more-jquery/)), so this needs to be added in order to make the blog function.
